### PR TITLE
Fix missing Argument for denote-sluggify

### DIFF
--- a/nm-org-roam-to-denote.el
+++ b/nm-org-roam-to-denote.el
@@ -52,7 +52,7 @@ It returns creation timestamp of NODE, which is obtained using `nm--roam-node-ct
   (let* ((id (nm--roam-node-denote-id node))
          (tags (mapcar #'downcase (org-roam-node-tags node)))
          (title (or (string-replace "/" "-" (org-roam-node-title node)) "untitled")))
-    (concat id "--" (denote-sluggify title) "__" (string-join tags "_") ".org")))
+    (concat id "--" (denote-sluggify-title title) "__" (string-join tags "_") ".org")))
 
 (defun nm--org-element-save-to-buffer (el)
   "Save `org-element' EL back in `current-buffer'.


### PR DESCRIPTION
In addition to the switch to org-mode, denote-sluggify expected a second Argument for the Component. Passing "title" as the component didn't work for me, but `denote-sluggify-title` made this run fine.