### PR TITLE
Remove properties drawer fully in the presence of optional entries

### DIFF
--- a/nm-org-roam-to-denote.el
+++ b/nm-org-roam-to-denote.el
@@ -124,7 +124,7 @@ Behavior:
       (insert (org-file-contents file))
       (goto-char (point-min))
       ;; Delete the properties drawer roam inserts on top
-      (delete-region (point) (line-beginning-position 4))
+      (delete-region (point) (1+ (search-forward ":END:")))
       (org-mode)
       (nm--convert-roam-links-to-denote new-name)
 


### PR DESCRIPTION
The properties drawer has at least three lines but can have more, e.g. if there is a ROAM-REFS line.